### PR TITLE
Fix app name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# WeekNumberWindowsTray
+# WeekNumberTrayIcon
 
-A simple Windows tray application that displays the current week number in the system tray. This project is designed to provide an at-a-glance reference for the current week, featuring a configurable user interface with options for font size, text color, and automatic system theme adaptation.
+**WeekNumberTrayIcon** is a simple Windows tray application that displays the current week number in the system tray. This project is designed to provide an at-a-glance reference for the current week, featuring a configurable user interface with options for font size, text color, and automatic system theme adaptation.
 
 ![image](https://github.com/user-attachments/assets/7597cb82-5e20-4079-a880-ae1ff9aaaf2f)
 
@@ -57,7 +57,7 @@ Add the application to the startup folder so you don't have to start it manually
 3. Execute ⊞ + R (Windows key + R) combination in the windows type in shell:startup
 4. Paste there the application reference
 
-Allow WeekTrayNumber to be shown in the tray bar, if you dont follow this step the icon well be hidden by default
+Allow **WeekNumberTrayIcon** to be shown in the tray bar; if you do not follow this step the icon will be hidden by default
 1. Right click on the task bar and select Taskbar settings
 2. Now navigate to Other sytem tray icons
 3. Find WeekNumberTrayIcon and enable it


### PR DESCRIPTION
## Summary
- rename README header to WeekNumberTrayIcon
- remove incorrect 'WeekTrayNumber' reference
- keep consistent naming of application

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ba1a9d74c83328d210c6a120d96fa