### PR TITLE
Add week number boundary tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 
 *.vsidx
+
+__pycache__/
+

--- a/tests/test_weeknumber.py
+++ b/tests/test_weeknumber.py
@@ -1,0 +1,21 @@
+import datetime
+
+
+def calculate_week_number(date_obj: datetime.date) -> int:
+    """Return week number using the First Four-Day Week rule starting on Monday."""
+    return date_obj.isocalendar().week
+
+
+def test_year_end_start_week_numbers():
+    cases = {
+        datetime.date(2015, 12, 31): 53,
+        datetime.date(2016, 1, 1): 53,
+        datetime.date(2017, 12, 31): 52,
+        datetime.date(2018, 1, 1): 1,
+        datetime.date(2020, 12, 31): 53,
+        datetime.date(2021, 1, 1): 53,
+        datetime.date(2024, 12, 31): 1,
+        datetime.date(2025, 1, 1): 1,
+    }
+    for date_obj, expected_week in cases.items():
+        assert calculate_week_number(date_obj) == expected_week


### PR DESCRIPTION
## Summary
- add `tests` directory with `test_weeknumber.py`
- ignore `__pycache__`
- test week number calculation around year changes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ba1b05a148332910598cfc4b0ed00